### PR TITLE
Path Fix to load swagger spec when sdk is used with Actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adobeio-cna-core-analytics",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Adobe Analytics SDK",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,6 @@ governing permissions and limitations under the License.
 'use strict'
 
 const Swagger = require('swagger-client')
-const fs = require('fs')
-const path = require('path')
 
 function init (companyId, apiKey, token) {
   return new Promise((resolve, reject) => {
@@ -33,10 +31,9 @@ function init (companyId, apiKey, token) {
 class AnalyticsCoreAPI {
   async init (companyId, apiKey, token) {
     // init swagger client
-    const swaggerJsonPath = path.join(__dirname, './../spec/analytics_api.json')
-    const swaggerJson = JSON.parse(fs.readFileSync(swaggerJsonPath, 'UTF-8'))
+    const spec = require('../spec/analytics_api.json')
     const swagger = new Swagger({
-      spec: swaggerJson,
+      spec: spec,
       requestInterceptor: req => {
         this.__setHeaders(req, this)
       },


### PR DESCRIPTION
__dirname for actions was resolving to action container root where runner.js exists. This was causing sdk to fail when run as action.

Fixed this path issue to load swagger jspn.