### PR TITLE
Remove deps on system modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "unit-tests": "jest --ci -w=2"
   },
   "dependencies": {
-    "fs": "0.0.1-security",
-    "path": "^0.12.7",
     "swagger-client": "^3.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In fact, checking the items on the npm registry:
1. `path` is a copy of the node.js path module, and was published 4 years ago (security risk)
2. `fs` is reserved by npm, and does not do anything